### PR TITLE
Implement notification protocol endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Aplicación web basada en FastAPI para registrar movimientos de dinero y factura
 - **Facturas:** Para la cuenta de facturación se cargan facturas de compra y venta. El sistema calcula automáticamente IVA e IIBB.
 - **Transacciones frecuentes:** Plantillas para agilizar carga de movimientos repetitivos.
 - **Usuarios y permisos:** Registro de usuarios, inicio de sesión, aprobación por administrador y roles de administrador.
+- **Notificaciones:** Recepción y consulta de notificaciones interoperables con una app hermana mediante HMAC y claves de idempotencia.
 
 ## Guía rápida de uso
 
@@ -19,6 +20,23 @@ Aplicación web basada en FastAPI para registrar movimientos de dinero y factura
 5. Aprovecha las transacciones frecuentes para movimientos repetitivos.
 
 Consulta [USAGE.md](USAGE.md) para una guía más detallada.
+
+## Notificaciones interoperables
+
+La aplicación expone el endpoint `/notificaciones` que implementa el protocolo compartido con la app hermana.
+
+- **POST `/notificaciones`**
+  - Con encabezados `X-Timestamp`, `X-Idempotency-Key`, `X-Source-App` y `X-Signature` válidos se aceptan notificaciones entrantes y se guardan como *unread* (respuesta `202`).
+  - Con cuerpo `{"action": "ack", "id": "<uuid>"}` marca la notificación como leída y responde `200`.
+- **GET `/notificaciones`** permite listar, filtrar por estado/topic/type, paginar mediante cursor y opcionalmente incluir `unread_count`.
+
+Variables de entorno relevantes:
+
+- `NOTIF_SHARED_SECRET`: secreto compartido para firmar y validar notificaciones (obligatorio).
+- `NOTIF_SOURCE_APP`: identificador propio (`app-a` o `app-b`, default `app-a`).
+- `PEER_BASE_URL`: URL HTTPS base de la app hermana para envíos salientes.
+
+Existe además una tarea en segundo plano que elimina diariamente las notificaciones leídas con más de 90 días de antigüedad.
 
 ## Cálculos de moneda
 

--- a/app/routes/notifications.py
+++ b/app/routes/notifications.py
@@ -1,0 +1,246 @@
+"""Notification endpoints implementing the shared protocol."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi.responses import JSONResponse
+from pydantic import ValidationError
+from sqlalchemy import and_, func, or_, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from auth import get_current_user
+from config.db import get_db
+from models import Notification, NotificationStatus
+from schemas import NotificationAck, NotificationListResponse, NotificationOut, NotificationPayload
+from services.notifications import (
+    ALLOWED_SOURCE_APPS,
+    decode_cursor,
+    encode_cursor,
+    inbound_rate_limiter,
+    require_shared_secret,
+    validate_timestamp,
+    verify_signature,
+)
+
+router = APIRouter(prefix="/notificaciones", tags=["notifications"])
+
+
+def _ensure_user(user) -> None:
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="No autorizado")
+
+
+def _normalize_datetime(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+@router.get("", response_model=NotificationListResponse)
+def list_notifications(
+    status_filter: str = Query("unread", alias="status"),
+    since: datetime | None = Query(None),
+    topic: str | None = Query(None),
+    type_filter: str | None = Query(None, alias="type"),
+    limit: int = Query(50, ge=1, le=100),
+    cursor: str | None = Query(None),
+    include: str | None = Query(None),
+    db: Session = Depends(get_db),
+    user=Depends(get_current_user),
+) -> NotificationListResponse:
+    _ensure_user(user)
+
+    query = select(Notification).order_by(
+        Notification.occurred_at.desc(), Notification.id.desc()
+    )
+
+    if status_filter == "unread":
+        query = query.where(Notification.status == NotificationStatus.UNREAD)
+    elif status_filter == "read":
+        query = query.where(Notification.status == NotificationStatus.READ)
+    elif status_filter != "all":
+        raise HTTPException(status_code=400, detail="Parámetro status inválido")
+
+    if since is not None:
+        query = query.where(Notification.occurred_at >= _normalize_datetime(since))
+
+    if topic:
+        query = query.where(Notification.topic == topic)
+
+    if type_filter:
+        query = query.where(Notification.type == type_filter)
+
+    if cursor:
+        try:
+            cursor_occurred_at, cursor_id = decode_cursor(cursor)
+        except Exception as exc:  # pragma: no cover - invalid cursor branch
+            raise HTTPException(status_code=400, detail="Cursor inválido") from exc
+        query = query.where(
+            or_(
+                Notification.occurred_at < cursor_occurred_at,
+                and_(
+                    Notification.occurred_at == cursor_occurred_at,
+                    Notification.id < cursor_id,
+                ),
+            )
+        )
+
+    stmt = query.limit(limit + 1)
+    items = db.execute(stmt).scalars().all()
+    has_more = len(items) > limit
+    items = items[:limit]
+
+    next_cursor: Optional[str] = None
+    if has_more and items:
+        last_item = items[-1]
+        next_cursor = encode_cursor(last_item.occurred_at, last_item.id)
+
+    include_flags = {flag.strip() for flag in include.split(",") if flag} if include else set()
+
+    unread_count: Optional[int] = None
+    if "unread_count" in include_flags:
+        unread_count = (
+            db.execute(
+                select(func.count()).where(Notification.status == NotificationStatus.UNREAD)
+            ).scalar_one()
+        )
+
+    return NotificationListResponse(
+        items=[NotificationOut.model_validate(item) for item in items],
+        cursor=next_cursor,
+        unread_count=unread_count,
+    )
+
+
+@router.post("", status_code=status.HTTP_202_ACCEPTED)
+async def create_or_ack_notification(
+    request: Request, db: Session = Depends(get_db), user=Depends(get_current_user)
+):
+    body_bytes = await request.body()
+    content_type = request.headers.get("content-type", "")
+    if "application/json" not in content_type.lower():
+        raise HTTPException(status_code=415, detail="Content-Type inválido")
+
+    try:
+        raw_text = body_bytes.decode("utf-8") if body_bytes else "{}"
+        payload = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=400, detail="JSON inválido") from exc
+
+    signature = request.headers.get("X-Signature")
+
+    if signature:
+        timestamp_header = request.headers.get("X-Timestamp")
+        idempotency_key = request.headers.get("X-Idempotency-Key")
+        source_app = request.headers.get("X-Source-App")
+
+        if not (timestamp_header and idempotency_key and source_app):
+            raise HTTPException(status_code=400, detail="Headers faltantes")
+
+        if source_app not in ALLOWED_SOURCE_APPS:
+            raise HTTPException(status_code=401, detail="Source app inválida")
+
+        try:
+            validate_timestamp(timestamp_header)
+        except ValueError as exc:
+            raise HTTPException(status_code=401, detail="Timestamp inválido") from exc
+
+        if not inbound_rate_limiter.check_and_increment(source_app):
+            raise HTTPException(status_code=429, detail="Rate limit excedido")
+
+        secret = require_shared_secret()
+        if not verify_signature(secret, timestamp_header, body_bytes, signature):
+            raise HTTPException(status_code=401, detail="Firma inválida")
+
+        try:
+            UUID(idempotency_key)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail="Idempotency key inválida") from exc
+
+        existing = (
+            db.execute(
+                select(Notification).where(Notification.idempotency_key == idempotency_key)
+            )
+            .scalars()
+            .first()
+        )
+        if existing:
+            return JSONResponse(
+                status_code=status.HTTP_202_ACCEPTED,
+                content={"status": "accepted", "id": str(existing.id), "dedup": True},
+            )
+
+        try:
+            payload_model = NotificationPayload.model_validate(payload)
+        except ValidationError as exc:
+            raise HTTPException(status_code=422, detail=exc.errors()) from exc
+
+        notification = Notification(
+            type=payload_model.type,
+            title=payload_model.title,
+            body=payload_model.body,
+            deeplink=payload_model.deeplink,
+            topic=payload_model.topic,
+            priority=payload_model.priority,
+            occurred_at=_normalize_datetime(payload_model.occurred_at),
+            status=NotificationStatus.UNREAD,
+            variables=payload_model.variables,
+            idempotency_key=idempotency_key,
+            source_app=source_app,
+        )
+        db.add(notification)
+        try:
+            db.commit()
+        except IntegrityError:
+            db.rollback()
+            existing = (
+                db.execute(
+                    select(Notification).where(Notification.idempotency_key == idempotency_key)
+                )
+                .scalars()
+                .first()
+            )
+            if existing:
+                return JSONResponse(
+                    status_code=status.HTTP_202_ACCEPTED,
+                    content={"status": "accepted", "id": str(existing.id), "dedup": True},
+                )
+            raise
+
+        db.refresh(notification)
+        return JSONResponse(
+            status_code=status.HTTP_202_ACCEPTED,
+            content={"status": "accepted", "id": str(notification.id), "dedup": False},
+        )
+
+    if isinstance(payload, dict) and payload.get("action") == "ack":
+        _ensure_user(user)
+        try:
+            ack = NotificationAck.model_validate(payload)
+        except ValidationError as exc:
+            raise HTTPException(status_code=400, detail="Payload inválido") from exc
+
+        try:
+            notification_id = UUID(ack.id)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail="ID inválido") from exc
+
+        notification = db.get(Notification, notification_id)
+        if not notification:
+            raise HTTPException(status_code=404, detail="Notificación no encontrada")
+
+        if notification.status != NotificationStatus.READ or notification.read_at is None:
+            notification.status = NotificationStatus.READ
+            notification.read_at = datetime.now(timezone.utc)
+            db.add(notification)
+            db.commit()
+
+        return JSONResponse(status_code=status.HTTP_200_OK, content={"status": "ok"})
+
+    raise HTTPException(status_code=400, detail="Operación no soportada")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,9 +1,10 @@
 from datetime import date, datetime
 from decimal import Decimal
-from typing import List
+from typing import Any, List, Literal
 
 from pydantic import BaseModel, conint
 from config.constants import Currency, InvoiceType
+from models import NotificationPriority, NotificationStatus
 
 class AccountIn(BaseModel):
     name: str
@@ -150,3 +151,41 @@ class UserOut(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class NotificationPayload(BaseModel):
+    type: str
+    occurred_at: datetime
+    title: str
+    body: str
+    deeplink: str | None = None
+    topic: str | None = None
+    priority: NotificationPriority = NotificationPriority.NORMAL
+    variables: dict[str, Any] | None = None
+
+
+class NotificationOut(BaseModel):
+    id: str
+    type: str
+    title: str
+    body: str
+    deeplink: str | None = None
+    topic: str | None = None
+    priority: NotificationPriority
+    status: NotificationStatus
+    occurred_at: datetime
+    variables: dict[str, Any] | None = None
+
+    class Config:
+        from_attributes = True
+
+
+class NotificationListResponse(BaseModel):
+    items: List[NotificationOut]
+    cursor: str | None = None
+    unread_count: int | None = None
+
+
+class NotificationAck(BaseModel):
+    action: Literal["ack"]
+    id: str

--- a/app/services/notifications.py
+++ b/app/services/notifications.py
@@ -1,0 +1,233 @@
+"""Notification helpers: signature, sending and retention."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import os
+import threading
+import time
+import uuid
+import hmac
+import hashlib
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import httpx
+from sqlalchemy import delete
+from sqlalchemy.orm import Session
+
+from config.db import SessionLocal
+from models import Notification, NotificationStatus
+
+LOGGER = logging.getLogger(__name__)
+
+SIGNATURE_PREFIX = "sha256="
+TIMESTAMP_WINDOW_SECONDS = 300
+INBOUND_RATE_LIMIT = 60
+INBOUND_RATE_WINDOW_SECONDS = 60
+RETENTION_DAYS = 90
+RETENTION_INTERVAL_SECONDS = 24 * 60 * 60
+ALLOWED_SOURCE_APPS = {"app-a", "app-b"}
+
+
+def require_shared_secret() -> str:
+    secret = os.getenv("NOTIF_SHARED_SECRET")
+    if not secret:
+        raise RuntimeError("NOTIF_SHARED_SECRET is not configured")
+    return secret
+
+
+def _require_source_app() -> str:
+    app_name = os.getenv("NOTIF_SOURCE_APP", "app-a")
+    if app_name not in ALLOWED_SOURCE_APPS:
+        raise RuntimeError("NOTIF_SOURCE_APP must be one of app-a|app-b")
+    return app_name
+
+
+def compute_signature(secret: str, timestamp: str, body: bytes) -> str:
+    """Return the expected HMAC signature for the payload."""
+
+    message = timestamp.encode("utf-8") + b"." + body
+    digest = hmac.new(secret.encode("utf-8"), message, hashlib.sha256).hexdigest()
+    return f"{SIGNATURE_PREFIX}{digest}"
+
+
+def verify_signature(secret: str, timestamp: str, body: bytes, provided: str) -> bool:
+    expected = compute_signature(secret, timestamp, body)
+    return hmac.compare_digest(expected, provided)
+
+
+def validate_timestamp(timestamp: str, window_seconds: int = TIMESTAMP_WINDOW_SECONDS) -> int:
+    value = int(timestamp)
+    now = int(time.time())
+    if abs(now - value) > window_seconds:
+        raise ValueError("timestamp outside window")
+    return value
+
+
+class SlidingWindowRateLimiter:
+    """In-memory sliding window limiter suitable for low traffic."""
+
+    def __init__(self, limit: int, window_seconds: int) -> None:
+        self.limit = limit
+        self.window_seconds = window_seconds
+        self._hits: dict[str, list[float]] = {}
+        self._lock = threading.Lock()
+
+    def check_and_increment(self, key: str) -> bool:
+        now = time.monotonic()
+        with self._lock:
+            hits = self._hits.setdefault(key, [])
+            cutoff = now - self.window_seconds
+            while hits and hits[0] <= cutoff:
+                hits.pop(0)
+            if len(hits) >= self.limit:
+                return False
+            hits.append(now)
+            return True
+
+
+inbound_rate_limiter = SlidingWindowRateLimiter(INBOUND_RATE_LIMIT, INBOUND_RATE_WINDOW_SECONDS)
+
+
+def _json_dumps(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+
+
+async def send_notification(
+    payload: dict[str, Any], *, client: httpx.AsyncClient | None = None, retries: int = 3
+) -> httpx.Response:
+    """Send a notification to the sibling application."""
+
+    base_url = os.getenv("PEER_BASE_URL")
+    if not base_url:
+        raise RuntimeError("PEER_BASE_URL is not configured")
+    if not base_url.lower().startswith("https://"):
+        raise RuntimeError("PEER_BASE_URL must use HTTPS")
+
+    payload = dict(payload)
+    occurred_at = payload.get("occurred_at")
+    if not occurred_at:
+        payload["occurred_at"] = datetime.now(timezone.utc).isoformat()
+    elif isinstance(occurred_at, datetime):
+        if occurred_at.tzinfo is None:
+            occurred_at = occurred_at.replace(tzinfo=timezone.utc)
+        else:
+            occurred_at = occurred_at.astimezone(timezone.utc)
+        payload["occurred_at"] = occurred_at.isoformat()
+
+    secret = require_shared_secret()
+    idempotency_key = str(uuid.uuid4())
+    timestamp = str(int(time.time()))
+    body_text = _json_dumps(payload)
+    signature = compute_signature(secret, timestamp, body_text.encode("utf-8"))
+    headers = {
+        "Content-Type": "application/json",
+        "X-Timestamp": timestamp,
+        "X-Idempotency-Key": idempotency_key,
+        "X-Source-App": _require_source_app(),
+        "X-Signature": signature,
+    }
+
+    owns_client = client is None
+    if client is None:
+        client = httpx.AsyncClient(timeout=httpx.Timeout(10.0))
+
+    attempt = 0
+    backoff = 1.0
+    last_exc: Exception | None = None
+    try:
+        while attempt < retries:
+            try:
+                response = await client.post(
+                    f"{base_url.rstrip('/')}/notificaciones",
+                    content=body_text.encode("utf-8"),
+                    headers=headers,
+                )
+            except (httpx.TimeoutException, httpx.TransportError) as exc:
+                last_exc = exc
+            else:
+                if response.status_code >= 500:
+                    last_exc = httpx.HTTPStatusError(
+                        "server error", request=response.request, response=response
+                    )
+                else:
+                    return response
+            attempt += 1
+            if attempt < retries:
+                await asyncio.sleep(backoff)
+                backoff *= 2
+        if last_exc:
+            raise last_exc
+        raise RuntimeError("Notification send failed")
+    finally:
+        if owns_client:
+            await client.aclose()
+
+
+def decode_cursor(token: str) -> tuple[datetime, uuid.UUID]:
+    raw = base64.urlsafe_b64decode(token.encode("utf-8")).decode("utf-8")
+    occurred_at_str, notification_id = raw.split("|", 1)
+    occurred_at = datetime.fromisoformat(occurred_at_str)
+    if occurred_at.tzinfo is None:
+        occurred_at = occurred_at.replace(tzinfo=timezone.utc)
+    return occurred_at, uuid.UUID(notification_id)
+
+
+def encode_cursor(occurred_at: datetime, notification_id: uuid.UUID) -> str:
+    if occurred_at.tzinfo is None:
+        occurred_at = occurred_at.replace(tzinfo=timezone.utc)
+    raw = f"{occurred_at.isoformat()}|{notification_id}".encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("utf-8")
+
+
+def purge_old_notifications(session: Session, cutoff: datetime) -> int:
+    stmt = delete(Notification).where(
+        Notification.status == NotificationStatus.READ,
+        Notification.read_at.is_not(None),
+        Notification.read_at < cutoff,
+    )
+    result = session.execute(stmt)
+    session.commit()
+    return result.rowcount or 0
+
+
+_retention_stop = threading.Event()
+_retention_thread: threading.Thread | None = None
+
+
+def _retention_worker() -> None:
+    while not _retention_stop.is_set():
+        cutoff = datetime.now(timezone.utc) - timedelta(days=RETENTION_DAYS)
+        try:
+            with SessionLocal() as session:
+                deleted = purge_old_notifications(session, cutoff)
+                if deleted:
+                    LOGGER.info("Purged %s old notifications", deleted)
+        except Exception:  # pragma: no cover - best effort logging
+            LOGGER.exception("Notification retention job failed")
+        _retention_stop.wait(RETENTION_INTERVAL_SECONDS)
+
+
+def start_notification_retention_job() -> None:
+    global _retention_thread
+    if _retention_thread and _retention_thread.is_alive():
+        return
+    _retention_stop.clear()
+    _retention_thread = threading.Thread(
+        target=_retention_worker, name="notification-retention", daemon=True
+    )
+    _retention_thread.start()
+
+
+def stop_notification_retention_job() -> None:
+    global _retention_thread
+    if not _retention_thread:
+        return
+    _retention_stop.set()
+    if _retention_thread.is_alive():
+        _retention_thread.join(timeout=1.0)
+    _retention_thread = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ uvicorn[standard]
 SQLAlchemy>=2
 psycopg2-binary
 pydantic
+httpx
 aiofiles
 jinja2
 python-multipart


### PR DESCRIPTION
## Summary
- add persistent notification model, schemas, and retention worker
- implement `/notificaciones` GET/POST with HMAC validation, idempotency, ack handling, and pagination
- document configuration for notifications and provide outbound sender helper

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d414e3b8ec8332aeae6c8f7108baa9