### PR TITLE
Support configurable notification signing algorithm

### DIFF
--- a/app/routes/transactions.py
+++ b/app/routes/transactions.py
@@ -30,6 +30,7 @@ def _notify_billing_movement(
     if not secret:
         raise RuntimeError("SECRETO_NOTIFICACIONES_IW_TA no está configurado")
     source_app = os.getenv("NOTIFICACIONES_INKWELL_SOURCE_APP", "movimientos-ta")
+    algorithm = os.getenv("NOTIFICACIONES_KEY_ALGORITHM")
 
     occurred_at = getattr(transaction, "created_at", None)
     if not isinstance(occurred_at, datetime):
@@ -77,6 +78,7 @@ def _notify_billing_movement(
             endpoint=endpoint,
             secret=secret,
             source_app=source_app,
+            algorithm=algorithm,
         )
     )
 


### PR DESCRIPTION
## Summary
- allow selecting the HMAC algorithm for notification signatures via the `NOTIFICACIONES_KEY_ALGORITHM` environment variable
- reuse the selected algorithm when generating and verifying signatures and propagate it when sending Inkwell notifications

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d44e87bc54833297a99eac28fceb57