### PR TITLE
Agregar filtros y reorganizar buscadores en movimientos y facturación

### DIFF
--- a/app/static/css/layout.css
+++ b/app/static/css/layout.css
@@ -152,16 +152,48 @@ body {
 }
 
 #table-controls {
-  gap: 8rem;
+  gap: 2rem;
   flex-wrap: wrap;
 }
 
+#table-controls .control-button {
+  flex: 0 0 auto;
+}
+
+#table-controls .search-wrapper {
+  flex: 1 1 24rem;
+  min-width: min(24rem, 100%);
+  display: flex;
+  justify-content: center;
+}
+
+.table-search-group {
+  width: min(40rem, 100%);
+}
+
 #search-box {
-  width: 50rem;
-  max-width: 100%;
+  width: 100%;
+  max-width: none;
   font-size: calc(1.1rem + 2pt);
-  margin-top: 1rem;
-  margin-bottom: 1rem;
+  margin: 0;
+}
+
+.btn-filter {
+  color: #0d47a1;
+  border-color: #0d47a1;
+  background-color: #ffffff;
+}
+
+.btn-filter:hover,
+.btn-filter:focus,
+.btn-filter.btn-filter-active {
+  color: #ffffff;
+  background-color: #0d47a1;
+  border-color: #0d47a1;
+}
+
+.btn-filter:focus {
+  box-shadow: 0 0 0 0.25rem rgba(13, 71, 161, 0.25);
 }
 
 #add-expense {

--- a/app/static/js/api.js
+++ b/app/static/js/api.js
@@ -3,13 +3,27 @@ export async function fetchAccounts(includeInactive = false) {
   return res.json();
 }
 
-export async function fetchTransactions(limit, offset) {
-  const res = await fetch(`/transactions?limit=${limit}&offset=${offset}`);
+export async function fetchTransactions(limit, offset, filters = {}) {
+  const params = new URLSearchParams({
+    limit: String(limit),
+    offset: String(offset),
+  });
+  if (filters.start_date) params.append('start_date', filters.start_date);
+  if (filters.end_date) params.append('end_date', filters.end_date);
+  if (filters.account_id) params.append('account_id', filters.account_id);
+  const res = await fetch(`/transactions?${params.toString()}`);
   return res.json();
 }
 
-export async function fetchInvoices(limit, offset) {
-  const res = await fetch(`/invoices?limit=${limit}&offset=${offset}`);
+export async function fetchInvoices(limit, offset, filters = {}) {
+  const params = new URLSearchParams({
+    limit: String(limit),
+    offset: String(offset),
+  });
+  if (filters.start_date) params.append('start_date', filters.start_date);
+  if (filters.end_date) params.append('end_date', filters.end_date);
+  if (filters.type) params.append('type', filters.type);
+  const res = await fetch(`/invoices?${params.toString()}`);
   return res.json();
 }
 

--- a/app/templates/billing.html
+++ b/app/templates/billing.html
@@ -1,10 +1,19 @@
 {% extends "base.html" %}
 {% block content %}
   <div id="table-container" class="flex-grow-1 overflow-auto">
-    <div id="table-controls" class="d-flex align-items-center justify-content-center my-4">
-      <button id="add-sale" class="btn action-btn d-inline-flex align-items-center"><i class="bi bi-file-earmark-arrow-up me-1"></i>Venta</button>
-      <input id="search-box" class="form-control" type="search" placeholder="Buscar">
-      <button id="add-purchase" class="btn action-btn d-inline-flex align-items-center"><i class="bi bi-file-earmark-arrow-down me-1"></i>Compra</button>
+    <div id="table-controls" class="d-flex align-items-center justify-content-center my-4 flex-wrap">
+      <div class="control-button">
+        <button id="add-sale" class="btn action-btn d-inline-flex align-items-center"><i class="bi bi-file-earmark-arrow-up me-1"></i>Venta</button>
+      </div>
+      <div class="search-wrapper">
+        <div class="input-group table-search-group">
+          <input id="search-box" class="form-control" type="search" placeholder="Buscar">
+          <button id="inv-filter-btn" class="btn btn-filter d-inline-flex align-items-center" type="button"><i class="bi bi-funnel me-1"></i>Filtros</button>
+        </div>
+      </div>
+      <div class="control-button">
+        <button id="add-purchase" class="btn action-btn d-inline-flex align-items-center"><i class="bi bi-file-earmark-arrow-down me-1"></i>Compra</button>
+      </div>
     </div>
     <div id="inv-table-wrapper" class="table-responsive">
       <table id="inv-table" class="table table-striped table-sm mb-0 w-100">
@@ -91,6 +100,43 @@
           <div class="modal-footer">
             <button type="submit" class="btn btn-primary">Guardar</button>
             <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="modal fade" id="inv-filter-modal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <form id="inv-filter-form">
+          <div class="modal-header">
+            <h5 class="modal-title">Filtros de facturación</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+          </div>
+          <div class="modal-body">
+            <div class="row g-3">
+              <div class="col-12 col-md-6">
+                <label class="form-label" for="inv-filter-start">Fecha inicio</label>
+                <input type="date" id="inv-filter-start" name="start_date" class="form-control">
+              </div>
+              <div class="col-12 col-md-6">
+                <label class="form-label" for="inv-filter-end">Fecha fin</label>
+                <input type="date" id="inv-filter-end" name="end_date" class="form-control">
+              </div>
+              <div class="col-12">
+                <label class="form-label" for="inv-filter-type">Tipo</label>
+                <select id="inv-filter-type" name="type" class="form-select">
+                  <option value="">Todos</option>
+                  <option value="sale">Ventas</option>
+                  <option value="purchase">Compras</option>
+                </select>
+              </div>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-outline-secondary" id="inv-clear-filters">Limpiar</button>
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cerrar</button>
+            <button type="submit" class="btn btn-primary">Aplicar</button>
           </div>
         </form>
       </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,10 +1,19 @@
 {% extends "base.html" %}
 {% block content %}
   <div id="table-container" class="flex-grow-1 overflow-auto">
-    <div id="table-controls" class="d-flex align-items-center justify-content-center my-4">
-      <button id="add-income" class="btn border border-primary text-primary action-btn d-inline-flex align-items-center"><i class="bi bi-box-arrow-in-right me-1"></i>Ingreso</button>
-      <input id="search-box" class="form-control" type="search" placeholder="Buscar">
-      <button id="add-expense" class="btn border border-warning action-btn d-inline-flex align-items-center"><i class="bi bi-box-arrow-right me-1"></i>Egreso</button>
+    <div id="table-controls" class="d-flex align-items-center justify-content-center my-4 flex-wrap">
+      <div class="control-button">
+        <button id="add-income" class="btn border border-primary text-primary action-btn d-inline-flex align-items-center"><i class="bi bi-box-arrow-in-right me-1"></i>Ingreso</button>
+      </div>
+      <div class="search-wrapper">
+        <div class="input-group table-search-group">
+          <input id="search-box" class="form-control" type="search" placeholder="Buscar">
+          <button id="tx-filter-btn" class="btn btn-filter d-inline-flex align-items-center" type="button"><i class="bi bi-funnel me-1"></i>Filtros</button>
+        </div>
+      </div>
+      <div class="control-button">
+        <button id="add-expense" class="btn border border-warning action-btn d-inline-flex align-items-center"><i class="bi bi-box-arrow-right me-1"></i>Egreso</button>
+      </div>
     </div>
     <div id="tx-table-wrapper" class="table-responsive">
       <table id="tx-table" class="table table-striped table-sm mb-0 w-100">
@@ -75,6 +84,41 @@
           <div class="modal-footer">
             <button type="submit" class="btn btn-primary">Guardar</button>
             <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="modal fade" id="tx-filter-modal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <form id="tx-filter-form">
+          <div class="modal-header">
+            <h5 class="modal-title">Filtros de movimientos</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+          </div>
+          <div class="modal-body">
+            <div class="row g-3">
+              <div class="col-12 col-md-6">
+                <label class="form-label" for="tx-filter-start">Fecha inicio</label>
+                <input type="date" id="tx-filter-start" name="start_date" class="form-control">
+              </div>
+              <div class="col-12 col-md-6">
+                <label class="form-label" for="tx-filter-end">Fecha fin</label>
+                <input type="date" id="tx-filter-end" name="end_date" class="form-control">
+              </div>
+              <div class="col-12">
+                <label class="form-label" for="tx-filter-account">Cuenta</label>
+                <select id="tx-filter-account" name="account_id" class="form-select">
+                  <option value="">Todas</option>
+                </select>
+              </div>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-outline-secondary" id="tx-clear-filters">Limpiar</button>
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cerrar</button>
+            <button type="submit" class="btn btn-primary">Aplicar</button>
           </div>
         </form>
       </div>


### PR DESCRIPTION
## Summary
- reubicar los buscadores de Movimientos y Facturación con un botón de filtros de borde azul junto a la barra
- incorporar modales de filtros en ambas pantallas y propagar los criterios al front-end
- actualizar los endpoints y utilidades para aceptar filtros por fecha, cuenta o tipo según corresponda

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5675471b8833298d826da599f2137