### PR TITLE
Fix filter button alignment with search field

### DIFF
--- a/app/static/css/layout.css
+++ b/app/static/css/layout.css
@@ -169,13 +169,22 @@ body {
 
 .table-search-group {
   width: min(40rem, 100%);
+  display: flex;
+  align-items: stretch;
+  gap: 0.5rem;
 }
 
 #search-box {
-  width: 100%;
+  flex: 1 1 auto;
+  width: auto;
   max-width: none;
   font-size: calc(1.1rem + 2pt);
   margin: 0;
+}
+
+.table-search-group .btn-filter {
+  flex: 0 0 auto;
+  white-space: nowrap;
 }
 
 .btn-filter {


### PR DESCRIPTION
## Summary
- update the search input group to use flex layout so the filter button stays beside the field
- keep the filter button from wrapping and allow the input to shrink as needed

## Testing
- not run (frontend change only)


------
https://chatgpt.com/codex/tasks/task_e_68d58629ec0083329005882fc26feb61