### PR TITLE
Make Inkwell document rows open a detail modal

### DIFF
--- a/app/static/js/inkwell_details.js
+++ b/app/static/js/inkwell_details.js
@@ -5,6 +5,150 @@ const invoicesTbody = document.querySelector('#inkwell-invoices tbody');
 const retentionsTbody = document.querySelector('#inkwell-retentions tbody');
 const refreshBtn = document.getElementById('refresh-inkwell');
 const alertBox = document.getElementById('inkwell-alert');
+const docModalEl = document.getElementById('inkwell-doc-modal');
+const docModalTitle = docModalEl?.querySelector('.modal-title') ?? null;
+const docModalBody = docModalEl?.querySelector('.modal-body') ?? null;
+const hasBootstrap = typeof window !== 'undefined' && window.bootstrap;
+const docModal =
+  docModalEl && hasBootstrap ? new window.bootstrap.Modal(docModalEl) : null;
+
+function attachRowInteraction(row, onActivate) {
+  row.classList.add('cursor-pointer');
+  row.setAttribute('role', 'button');
+  row.tabIndex = 0;
+  row.title = 'Ver detalle';
+  row.addEventListener('click', onActivate);
+  row.addEventListener('keydown', event => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onActivate();
+    }
+  });
+}
+
+function createDetailList(items) {
+  const wrapper = document.createElement('div');
+  wrapper.classList.add('border', 'rounded', 'p-3', 'bg-light');
+
+  const dl = document.createElement('dl');
+  dl.classList.add('row', 'mb-0', 'gy-1');
+
+  items.forEach(item => {
+    const dt = document.createElement('dt');
+    dt.classList.add('col-sm-5', 'col-md-4', 'fw-semibold');
+    if (item.emphasis) {
+      dt.classList.add('border-top', 'pt-2', 'mt-2');
+    }
+    dt.textContent = item.label;
+
+    const dd = document.createElement('dd');
+    dd.classList.add('col-sm-7', 'col-md-8', 'text-start');
+    if (item.align !== 'start') {
+      dd.classList.add('text-sm-end');
+    }
+    if (item.emphasis) {
+      dd.classList.add('border-top', 'pt-2', 'mt-2', 'fw-bold', 'fs-5');
+    }
+    if (item.wrap) {
+      dd.classList.add('text-break');
+    }
+    dd.textContent = item.value;
+    dl.append(dt, dd);
+  });
+
+  wrapper.appendChild(dl);
+  return wrapper;
+}
+
+function showDocumentModal(title, items) {
+  if (!docModal || !docModalTitle || !docModalBody) return;
+  docModalTitle.textContent = title;
+  docModalBody.innerHTML = '';
+  docModalBody.appendChild(createDetailList(items));
+  docModal.show();
+}
+
+function formatDate(value) {
+  return new Date(value).toLocaleDateString('es-AR');
+}
+
+function getInvoiceTypeText(type) {
+  if (type === 'sale') return 'Venta';
+  if (type === 'purchase') return 'Compra';
+  return type;
+}
+
+function resolveAccountName(invoice) {
+  const { account } = invoice;
+  if (account && typeof account === 'object') {
+    if ('name' in account && account.name) {
+      return account.name;
+    }
+    if ('title' in account && account.title) {
+      return account.title;
+    }
+  }
+  if (typeof account === 'string' && account.trim()) {
+    return account;
+  }
+  if (invoice.account_name) {
+    return invoice.account_name;
+  }
+  if (invoice.account_id) {
+    return `Cuenta #${invoice.account_id}`;
+  }
+  return '—';
+}
+
+function showInvoiceDetails(invoice) {
+  const baseAmount = Number(invoice.amount ?? 0);
+  const ivaAmount = Number(invoice.iva_amount ?? 0);
+  const iibbAmount = Number(invoice.iibb_amount ?? 0);
+  const percepcionesAmount = Number(invoice.percepciones ?? 0);
+  const total = baseAmount + ivaAmount + iibbAmount + percepcionesAmount;
+  const numberLabel = invoice.number ? `Factura ${invoice.number}` : `Factura #${invoice.id}`;
+
+  showDocumentModal(numberLabel, [
+    { label: 'Fecha', value: formatDate(invoice.date) },
+    { label: 'Tipo', value: getInvoiceTypeText(invoice.type) },
+    { label: 'Cuenta', value: resolveAccountName(invoice), wrap: true },
+    {
+      label: 'Concepto',
+      value: invoice.description && invoice.description.trim() ? invoice.description : '—',
+      align: 'start',
+      wrap: true
+    },
+    { label: 'Monto sin impuesto', value: `$ ${formatCurrency(baseAmount)}` },
+    { label: 'IVA', value: `$ ${formatCurrency(ivaAmount)}` },
+    { label: 'Ingresos Brutos', value: `$ ${formatCurrency(iibbAmount)}` },
+    { label: 'Percepciones', value: `$ ${formatCurrency(percepcionesAmount)}` },
+    { label: 'Total', value: `$ ${formatCurrency(total)}`, emphasis: true }
+  ]);
+}
+
+function showRetentionDetails(certificate) {
+  const numberLabel = certificate.number
+    ? `Certificado ${certificate.number}`
+    : `Certificado #${certificate.id}`;
+
+  showDocumentModal(numberLabel, [
+    { label: 'Fecha', value: formatDate(certificate.date) },
+    {
+      label: 'Tipo de impuesto',
+      value: certificate.retained_tax_type?.name || '—',
+      wrap: true
+    },
+    {
+      label: 'Factura vinculada',
+      value:
+        certificate.invoice_reference && certificate.invoice_reference.trim()
+          ? certificate.invoice_reference
+          : '—',
+      wrap: true
+    },
+    { label: 'Monto retenido', value: `$ ${formatCurrency(Number(certificate.amount ?? 0))}`, emphasis: true }
+  ]);
+}
 
 function renderEmptyRow(tbody, message) {
   const tr = document.createElement('tr');
@@ -24,8 +168,8 @@ function renderInvoices(invoices) {
   }
   invoices.forEach(inv => {
     const tr = document.createElement('tr');
-    const date = new Date(inv.date).toLocaleDateString('es-AR');
-    const typeText = inv.type === 'sale' ? 'Venta' : inv.type === 'purchase' ? 'Compra' : inv.type;
+    const date = formatDate(inv.date);
+    const typeText = getInvoiceTypeText(inv.type);
     const amount =
       Number(inv.amount || 0) +
       Number(inv.iva_amount || 0) +
@@ -35,6 +179,7 @@ function renderInvoices(invoices) {
       `<td class="text-center">${date}</td>` +
       `<td class="text-center">${typeText}</td>` +
       `<td class="text-end">$ ${formatCurrency(amount)}</td>`;
+    attachRowInteraction(tr, () => showInvoiceDetails(inv));
     invoicesTbody.appendChild(tr);
   });
 }
@@ -47,12 +192,13 @@ function renderRetentions(retentions) {
   }
   retentions.forEach(cert => {
     const tr = document.createElement('tr');
-    const date = new Date(cert.date).toLocaleDateString('es-AR');
+    const date = formatDate(cert.date);
     const typeName = cert.retained_tax_type?.name || '—';
     tr.innerHTML =
       `<td class="text-center">${date}</td>` +
       `<td class="text-center">${typeName}</td>` +
       `<td class="text-end">$ ${formatCurrency(cert.amount || 0)}</td>`;
+    attachRowInteraction(tr, () => showRetentionDetails(cert));
     retentionsTbody.appendChild(tr);
   });
 }

--- a/app/templates/inkwell_details.html
+++ b/app/templates/inkwell_details.html
@@ -39,9 +39,23 @@
           </div>
         </section>
       </div>
+      <div class="modal fade" id="inkwell-doc-modal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title">Detalle del documento</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+            </div>
+            <div class="modal-body"></div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cerrar</button>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </main>
 {% endblock %}
 {% block scripts %}
-  <script type="module" src="/static/js/inkwell_details.js?v=1"></script>
+  <script type="module" src="/static/js/inkwell_details.js?v=2"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a Bootstrap modal to the Inkwell detail page for document previews
- make invoice and retention rows clickable and populate the modal with formatted details

## Testing
- Manually verified with Playwright by loading the Inkwell page and opening a document modal

------
https://chatgpt.com/codex/tasks/task_e_68da9e4e37888332866c7fe9c42cdb03