### PR TITLE
Update Inkwell availability calculations and summary display

### DIFF
--- a/app/static/js/inkwell_calculator.js
+++ b/app/static/js/inkwell_calculator.js
@@ -1,0 +1,75 @@
+function toNumber(value) {
+  const num = Number(value ?? 0);
+  return Number.isFinite(num) ? num : 0;
+}
+
+function classifyRetention(certificate) {
+  const name = (certificate?.retained_tax_type?.name || '').toLowerCase();
+  if (!name) return 'other';
+  if (name.includes('iva')) return 'iva';
+  if (name.includes('iibb') || name.includes('ingresos brutos')) return 'iibb';
+  return 'other';
+}
+
+export function calculateInkwellTotals(billingData, summary) {
+  const invoices = Array.isArray(billingData?.invoices) ? billingData.invoices : [];
+  const retentions = Array.isArray(billingData?.retention_certificates)
+    ? billingData.retention_certificates
+    : [];
+
+  const income = toNumber(summary?.inkwell_income);
+  const expense = toNumber(summary?.inkwell_expense);
+
+  let purchaseIva = 0;
+  let salesIva = 0;
+  let sircreb = 0;
+  let ivaRetentions = 0;
+  let iibbRetentions = 0;
+  let perceptions = 0;
+  let otherAdditions = 0;
+
+  invoices.forEach(invoice => {
+    const ivaAmount = toNumber(invoice?.iva_amount);
+    const iibbAmount = toNumber(invoice?.iibb_amount);
+    const percepcionesAmount = toNumber(invoice?.percepciones);
+
+    if (invoice?.type === 'purchase') {
+      purchaseIva += ivaAmount;
+    } else if (invoice?.type === 'sale') {
+      salesIva += ivaAmount;
+      sircreb += iibbAmount;
+    }
+
+    perceptions += percepcionesAmount;
+  });
+
+  retentions.forEach(certificate => {
+    const amount = toNumber(certificate?.amount);
+    const category = classifyRetention(certificate);
+    if (category === 'iva') {
+      ivaRetentions += amount;
+    } else if (category === 'iibb') {
+      iibbRetentions += amount;
+    } else {
+      otherAdditions += amount;
+    }
+  });
+
+  const additions = purchaseIva + ivaRetentions + iibbRetentions + perceptions + otherAdditions;
+  const deductions = salesIva + sircreb;
+  const baseAvailable = income - expense;
+  const available = baseAvailable + additions - deductions;
+
+  return {
+    income,
+    expense,
+    purchaseIva,
+    ivaRetentions,
+    iibbRetentions,
+    perceptions: perceptions + otherAdditions,
+    salesIva,
+    sircreb,
+    baseAvailable,
+    available,
+  };
+}

--- a/app/templates/accounts.html
+++ b/app/templates/accounts.html
@@ -21,5 +21,5 @@
   </main>
 {% endblock %}
 {% block scripts %}
-  <script type="module" src="/static/js/accounts.js?v=1"></script>
+  <script type="module" src="/static/js/accounts.js?v=2"></script>
 {% endblock %}

--- a/app/templates/inkwell_details.html
+++ b/app/templates/inkwell_details.html
@@ -7,6 +7,25 @@
         <button id="refresh-inkwell" class="btn btn-outline-primary btn-sm">Actualizar</button>
       </div>
       <div id="inkwell-alert" class="alert alert-danger d-none" role="alert"></div>
+      <section id="inkwell-summary" class="mb-4 d-none">
+        <div class="row g-3">
+          <div class="col-12 col-lg-6">
+            <div class="border rounded p-3 h-100 bg-light-subtle">
+              <h3 class="h6 text-uppercase text-success fw-semibold">Suman</h3>
+              <ul id="inkwell-summary-add" class="list-unstyled mb-0"></ul>
+            </div>
+          </div>
+          <div class="col-12 col-lg-6">
+            <div class="border rounded p-3 h-100 bg-light-subtle">
+              <h3 class="h6 text-uppercase text-danger fw-semibold">Restan</h3>
+              <ul id="inkwell-summary-subtract" class="list-unstyled mb-0"></ul>
+            </div>
+          </div>
+        </div>
+        <div class="mt-3 text-end">
+          <p class="fs-5 fw-bold mb-0">Disponible Inkwell: <span id="inkwell-available-total" class="text-dark"></span></p>
+        </div>
+      </section>
       <div class="row g-4">
         <section class="col-12 col-lg-6">
           <h3 class="h5">Facturas Inkwell</h3>
@@ -57,5 +76,5 @@
   </main>
 {% endblock %}
 {% block scripts %}
-  <script type="module" src="/static/js/inkwell_details.js?v=2"></script>
+  <script type="module" src="/static/js/inkwell_details.js?v=3"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a shared calculator to derive Inkwell totals from billing invoices and retention certificates
- surface the detailed Inkwell breakdown in the Detalles Inkwell view and compute availability with the new formula
- update the billing account detail panel to reuse the new totals and subtract the Inkwell availability from the displayed total

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68daaea0e75883328783b75f7590310c