### PR TITLE
Add active filter summary to movimientos table

### DIFF
--- a/app/static/css/layout.css
+++ b/app/static/css/layout.css
@@ -156,6 +156,34 @@ body {
   flex-wrap: wrap;
 }
 
+#tx-filter-summary {
+  margin-bottom: 1.5rem;
+}
+
+.filter-summary {
+  background: linear-gradient(135deg, #f8fbff 0%, #ffffff 60%);
+  border-left: 0.35rem solid #0d47a1;
+  border-radius: 0.75rem;
+}
+
+.filter-summary-label {
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+}
+
+.filter-summary-chip {
+  background-color: #e8f0fe;
+  color: #0d47a1;
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+#tx-clear-filters-summary {
+  white-space: nowrap;
+}
+
 #table-controls .control-button {
   flex: 0 0 auto;
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -15,6 +15,14 @@
         <button id="add-expense" class="btn border border-warning action-btn d-inline-flex align-items-center"><i class="bi bi-box-arrow-right me-1"></i>Egreso</button>
       </div>
     </div>
+    <div id="tx-filter-summary" class="filter-summary card border-0 shadow-sm d-none">
+      <div class="card-body py-2 px-3 d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
+        <div id="tx-filter-summary-content" class="d-flex flex-wrap align-items-center gap-2"></div>
+        <button type="button" id="tx-clear-filters-summary" class="btn btn-sm btn-outline-secondary">
+          <i class="bi bi-x-circle me-1"></i>Limpiar filtros
+        </button>
+      </div>
+    </div>
     <div id="tx-table-wrapper" class="table-responsive">
       <table id="tx-table" class="table table-striped table-sm mb-0 w-100">
         <colgroup>


### PR DESCRIPTION
## Summary
- display an active filter summary card above the movimientos table with a clear action
- style the new summary banner to match the existing layout aesthetics
- update the movimientos script to maintain the summary contents and share filter clearing logic

## Testing
- Manual verification via uvicorn + Playwright screenshot


------
https://chatgpt.com/codex/tasks/task_e_68dad9e464e8833287b7d55c4dbe68e0