### PR TITLE
Add change audit log for exportable movements

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -114,6 +114,12 @@ class FrequentTransaction(Base):
     )
 
 
+class ExportableMovementEvent(str, Enum):
+    CREATED = "created"
+    UPDATED = "updated"
+    DELETED = "deleted"
+
+
 class ExportableMovement(Base):
     __tablename__ = "movimientos_exportables"
 
@@ -124,6 +130,33 @@ class ExportableMovement(Base):
     )
 
     transactions = relationship("Transaction", back_populates="exportable_movement")
+
+
+class ExportableMovementChange(Base):
+    __tablename__ = "movimientos_exportables_cambios"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    movement_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    event: Mapped[ExportableMovementEvent] = mapped_column(
+        SqlEnum(ExportableMovementEvent), nullable=False
+    )
+    occurred_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    payload: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+
+
+class ExportableMovementChangeSyncStatus(Base):
+    __tablename__ = "movimientos_exportables_cambios_sync_status"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    last_change_id: Mapped[int] = mapped_column(Integer, default=0)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        server_onupdate=func.now(),
+    )
 
 
 class User(Base):

--- a/app/routes/exportables.py
+++ b/app/routes/exportables.py
@@ -1,16 +1,53 @@
-from typing import List
+from typing import Any, List
 
-from typing import List
-
-from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import select
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import delete, func, select
 from sqlalchemy.orm import Session
 
 from config.db import get_db
-from models import ExportableMovement
-from schemas import ExportableMovementIn, ExportableMovementOut
+from models import (
+    ExportableMovement,
+    ExportableMovementChange,
+    ExportableMovementChangeSyncStatus,
+    ExportableMovementEvent,
+)
+from schemas import (
+    ExportableMovementChangeAck,
+    ExportableMovementChangeState,
+    ExportableMovementChangesResponse,
+    ExportableMovementIn,
+    ExportableMovementOut,
+)
 
 router = APIRouter(prefix="/movimientos_exportables")
+
+
+def record_change(
+    db: Session,
+    movement_id: int | None,
+    event: ExportableMovementEvent,
+    payload: dict[str, Any],
+) -> None:
+    change = ExportableMovementChange(
+        movement_id=movement_id,
+        event=event,
+        payload=payload,
+    )
+    db.add(change)
+
+
+def get_changes_sync_status(db: Session) -> ExportableMovementChangeSyncStatus:
+    sync_status = db.scalar(
+        select(ExportableMovementChangeSyncStatus)
+        .order_by(ExportableMovementChangeSyncStatus.id.asc())
+        .limit(1)
+    )
+    if not sync_status:
+        sync_status = ExportableMovementChangeSyncStatus()
+        db.add(sync_status)
+        db.commit()
+        db.refresh(sync_status)
+    return sync_status
 
 
 @router.post("", response_model=ExportableMovementOut)
@@ -19,6 +56,16 @@ def create_exportable(
 ):
     movement = ExportableMovement(**payload.dict())
     db.add(movement)
+    db.flush()
+    record_change(
+        db,
+        movement_id=movement.id,
+        event=ExportableMovementEvent.CREATED,
+        payload={
+            "id": movement.id,
+            "description": movement.description,
+        },
+    )
     db.commit()
     db.refresh(movement)
     return movement
@@ -42,8 +89,19 @@ def update_exportable(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Movimiento no encontrado",
         )
+    previous_description = movement.description
     for field, value in payload.dict().items():
         setattr(movement, field, value)
+    record_change(
+        db,
+        movement_id=movement.id,
+        event=ExportableMovementEvent.UPDATED,
+        payload={
+            "id": movement.id,
+            "description": movement.description,
+            "previous_description": previous_description,
+        },
+    )
     db.commit()
     db.refresh(movement)
     return movement
@@ -57,6 +115,85 @@ def delete_exportable(movement_id: int, db: Session = Depends(get_db)):
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Movimiento no encontrado",
         )
+    record_change(
+        db,
+        movement_id=movement.id,
+        event=ExportableMovementEvent.DELETED,
+        payload={
+            "id": movement.id,
+            "description": movement.description,
+            "deleted": True,
+        },
+    )
     db.delete(movement)
     db.commit()
     return {"ok": True}
+
+
+@router.get("/cambios", response_model=ExportableMovementChangesResponse)
+def list_exportable_changes(
+    since: int | None = Query(default=None, ge=0),
+    limit: int = Query(default=100, ge=1, le=500),
+    db: Session = Depends(get_db),
+):
+    sync_status = get_changes_sync_status(db)
+    last_confirmed_id = sync_status.last_change_id
+    effective_since = since if since is not None else last_confirmed_id
+
+    stmt = (
+        select(ExportableMovementChange)
+        .where(ExportableMovementChange.id > effective_since)
+        .order_by(ExportableMovementChange.id.asc())
+        .limit(limit + 1)
+    )
+    rows = db.scalars(stmt).all()
+    has_more = len(rows) > limit
+    if has_more:
+        rows = rows[:limit]
+    checkpoint_id = rows[-1].id if rows else effective_since
+
+    return ExportableMovementChangesResponse(
+        last_confirmed_id=last_confirmed_id,
+        checkpoint_id=checkpoint_id,
+        has_more=has_more,
+        changes=rows,
+    )
+
+
+@router.post("/cambios/ack", response_model=ExportableMovementChangeState)
+def acknowledge_exportable_changes(
+    payload: ExportableMovementChangeAck, db: Session = Depends(get_db)
+):
+    sync_status = get_changes_sync_status(db)
+    checkpoint_id = payload.checkpoint_id
+
+    if checkpoint_id < sync_status.last_change_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="El checkpoint es menor al último confirmado",
+        )
+
+    max_change_id = db.scalar(select(func.max(ExportableMovementChange.id))) or 0
+    if checkpoint_id > max_change_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="El checkpoint indicado no existe",
+        )
+
+    if checkpoint_id == sync_status.last_change_id:
+        return sync_status
+
+    sync_status.last_change_id = checkpoint_id
+    db.add(sync_status)
+    db.commit()
+    db.refresh(sync_status)
+
+    if checkpoint_id:
+        db.execute(
+            delete(ExportableMovementChange).where(
+                ExportableMovementChange.id <= checkpoint_id
+            )
+        )
+        db.commit()
+
+    return sync_status

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -114,6 +114,36 @@ class ExportableMovementOut(ExportableMovementIn):
         from_attributes = True
 
 
+class ExportableMovementChangeEvent(BaseModel):
+    id: int
+    movement_id: int | None = None
+    event: Literal["created", "updated", "deleted"]
+    occurred_at: datetime
+    payload: dict[str, Any]
+
+    class Config:
+        from_attributes = True
+
+
+class ExportableMovementChangesResponse(BaseModel):
+    last_confirmed_id: int
+    checkpoint_id: int
+    has_more: bool
+    changes: List[ExportableMovementChangeEvent]
+
+
+class ExportableMovementChangeAck(BaseModel):
+    checkpoint_id: conint(ge=0)
+
+
+class ExportableMovementChangeState(BaseModel):
+    last_change_id: int
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
 class AccountBalance(BaseModel):
     account_id: int
     name: str


### PR DESCRIPTION
## Summary
- add audit tables and event enums for exportable movement changes
- record creation, update, and deletion events with payload metadata
- expose endpoints to fetch and acknowledge change events for downstream sync

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbf416b8ec8332aa1add6b2a585b98