### PR TITLE
Allow movimientos_exportables changes endpoint for billing account

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -47,6 +47,7 @@ async def require_login_middleware(request: Request, call_next):
         "/health",
         "/facturacion-info",
         "/movimientos_cuenta_facturada",
+        "/movimientos_cuenta_facturada/movimientos_exportables/cambios",
     }
     if not request.session.get("user_id") and not path.startswith("/static") and path not in allowed:
         return RedirectResponse("/login")


### PR DESCRIPTION
## Summary
- add the movimientos_exportables changes endpoint under the billing account prefix to the middleware's allowlist so it can be accessed without login

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc2548a9c88332949eb759fb01656f