### PR TITLE
Allow unauthenticated billing export subpaths

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -44,16 +44,20 @@ async def require_login_middleware(request: Request, call_next):
     ):
         return await call_next(request)
 
-    allowed = {
+    allowed_exact = {
         "/login",
         "/register",
         "/health",
         "/facturacion-info",
-        "/movimientos_cuenta_facturada",
-        "/movimientos_cuenta_facturada/movimientos_exportables/cambios",
-        "/movimientos_cuenta_facturada/movimientos_exportables/cambios/ack",
     }
-    if not request.session.get("user_id") and not path.startswith("/static") and path not in allowed:
+    allowed_prefixes = (
+        "/movimientos_cuenta_facturada",
+        "/static",
+    )
+    if not request.session.get("user_id") and not (
+        path in allowed_exact
+        or any(path.startswith(prefix) for prefix in allowed_prefixes)
+    ):
         return RedirectResponse("/login")
     return await call_next(request)
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -46,22 +46,26 @@ class TransactionWithBalance(TransactionOut):
 
 
 class BillingSyncAck(BaseModel):
-    checkpoint_id: conint(ge=0)
+    movements_checkpoint_id: conint(ge=0)
+    changes_checkpoint_id: conint(ge=0)
 
 
 class BillingSyncState(BaseModel):
     last_transaction_id: int
-    updated_at: datetime
-
-    class Config:
-        from_attributes = True
+    last_change_id: int
+    transactions_updated_at: datetime
+    changes_updated_at: datetime
 
 
 class BillingMovementsResponse(BaseModel):
-    last_confirmed_id: int
-    checkpoint_id: int
-    has_more: bool
+    last_confirmed_transaction_id: int
+    transactions_checkpoint_id: int
+    has_more_transactions: bool
     transactions: List[TransactionOut]
+    last_confirmed_change_id: int
+    changes_checkpoint_id: int
+    has_more_changes: bool
+    changes: List["ExportableMovementChangeEvent"]
 
 
 class InvoiceCreate(BaseModel):
@@ -261,3 +265,6 @@ class NotificationListResponse(BaseModel):
 class NotificationAck(BaseModel):
     action: Literal["ack"]
     id: str
+
+
+BillingMovementsResponse.update_forward_refs()


### PR DESCRIPTION
## Summary
- relax the login middleware to whitelist every billing export subroute
- treat `/static` as an allowed prefix instead of a hardcoded exception

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc46d9dfd483328d9d05dcd838ebac