### PR TITLE
Fix checkpoint fallback when no exportable changes

### DIFF
--- a/app/routes/billing_movements.py
+++ b/app/routes/billing_movements.py
@@ -115,9 +115,7 @@ def list_billing_movements(
     if change_rows:
         changes_checkpoint_id = change_rows[-1].id
     else:
-        changes_checkpoint_id = min(
-            effective_changes_since, change_sync_status.last_change_id
-        )
+        changes_checkpoint_id = change_sync_status.last_change_id
 
     return BillingMovementsResponse(
         last_confirmed_transaction_id=last_confirmed_id,


### PR DESCRIPTION
## Summary
- ensure empty change responses return the confirmed change checkpoint instead of the request cursor
- extend the queue purge regression test to cover acknowledgements from earlier cursors

## Testing
- pytest tests/test_billing_transaction_events.py

------
https://chatgpt.com/codex/tasks/task_e_68dd50a6fba88332b3bad943931a75af