### PR TITLE
Implement server-driven transaction pagination search

### DIFF
--- a/app/static/js/api.js
+++ b/app/static/js/api.js
@@ -11,6 +11,10 @@ export async function fetchTransactions(limit, offset, filters = {}) {
   if (filters.start_date) params.append('start_date', filters.start_date);
   if (filters.end_date) params.append('end_date', filters.end_date);
   if (filters.account_id) params.append('account_id', filters.account_id);
+  if (filters.q) {
+    const search = filters.q.trim();
+    if (search) params.append('q', search);
+  }
   const res = await fetch(`/transactions?${params.toString()}`);
   return res.json();
 }


### PR DESCRIPTION
## Summary
- add backend support for a `q` parameter that filters transactions by description or account name before paginating
- propagate the search term from the frontend when requesting pages and manage debounced reloads while keeping 50-item batches

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de8dd5d5808332b04c28992954da2e